### PR TITLE
Handle Integer instead of Fixnum for hash-code computation.

### DIFF
--- a/phc-adt-lib/phc-adt/node-low-level.hl.rkt
+++ b/phc-adt-lib/phc-adt/node-low-level.hl.rkt
@@ -221,7 +221,7 @@ them with a special marker.
 
 @chunk[<node-hash>
        (: node-hash (∀ (fieldᵢ/τ …)
-                       (→ (node-id fieldᵢ/τ … Any Any) (→ Any Fixnum) Fixnum)))
+                       (→ (node-id fieldᵢ/τ … Any Any) (→ Any Integer) Integer)))
        (define (node-hash nd racket-recur-hash)
          (if (eq? (raw-node-database ((struct-accessor node-id raw) nd))
                   'unique-copy)
@@ -275,9 +275,9 @@ To combine hash codes, we simply compute their @elem[#:style 'tt]{xor}. Later
 versions of this library may use more sophisticated mechanisms.
 
 @chunk[<combine-hash-codes>
-       (: combine-hash-codes (→ Fixnum * Fixnum))
+       (: combine-hash-codes (→ Integer * Integer))
        (define (combine-hash-codes . fixnums)
-         (apply fxxor fixnums))]
+         (apply bitwise-xor fixnums))]
 
 @subsection{Caching node equality}
 


### PR DESCRIPTION
Now that these are type checked by Typed Racket in 7.5, it's a
problem that the documentation doesn't promise that these will be a
Fixnum. Switch to using Integer, and change the use of fxxor to
match.